### PR TITLE
Use new vim.validate API for Neovim 0.12 compatibility

### DIFF
--- a/lua/telescope-oil/settings.lua
+++ b/lua/telescope-oil/settings.lua
@@ -12,12 +12,10 @@ M.current = M._DEFAULT_SETTINGS
 
 M.set = function(opts)
 	M.current = vim.tbl_deep_extend("force", M.current, opts)
-	vim.validate({
-		hidden = { M.current.hidden, "boolean" },
-		debug = { M.current.debug, "boolean" },
-		no_ignore = { M.current.no_ignore, "boolean" },
-		show_preview = { M.current.show_preview, "boolean" },
-	})
+	vim.validate("hidden", M.current.hidden, "boolean")
+	vim.validate("debug", M.current.debug, "boolean")
+	vim.validate("no_ignore", M.current.no_ignore, "boolean")
+	vim.validate("show_preview", M.current.show_preview, "boolean")
 end
 
 return M


### PR DESCRIPTION
## Summary

Neovim 0.12 deprecated the single-table form of `vim.validate({...})` in favor of the positional form `vim.validate(name, value, validator, optional_or_msg)`. The old form is slated for removal in Neovim 1.0, and currently produces a warning in `:checkhealth vim.deprecated` whenever a user calls `require("telescope-oil.settings").set(...)`:

```
WARNING vim.validate{<table>} is deprecated. Feature will be removed in Nvim 1.0
  stack traceback:
    .../telescope-oil.nvim/lua/telescope-oil/settings.lua:15
```

This PR expands the single table call in `lua/telescope-oil/settings.lua` into four positional-form calls — one per field. Behavior is unchanged: the same four fields (`hidden`, `debug`, `no_ignore`, `show_preview`) are still validated as booleans, and a bad value produces an equivalent error.

## Change

```diff
-	vim.validate({
-		hidden = { M.current.hidden, "boolean" },
-		debug = { M.current.debug, "boolean" },
-		no_ignore = { M.current.no_ignore, "boolean" },
-		show_preview = { M.current.show_preview, "boolean" },
-	})
+	vim.validate("hidden", M.current.hidden, "boolean")
+	vim.validate("debug", M.current.debug, "boolean")
+	vim.validate("no_ignore", M.current.no_ignore, "boolean")
+	vim.validate("show_preview", M.current.show_preview, "boolean")
```

## Compatibility

The positional form was added in Neovim 0.11 (the same release that deprecated the table form — see `:help deprecated-0.11`). Since `telescope.nvim` itself requires Neovim ≥ 0.11.7, this change cannot regress any currently-supported user of `telescope-oil.nvim`.
